### PR TITLE
release: v1.0.1 release was added

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,11 @@
 jobs:
   build:
+    filters:
+        branches:
+          only:
+            - main
+            - feature
+            - develop
     docker:
       - image: cimg/rust:1.60.0
     

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quicktest"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Luis Miguel Báez <es.luismiguelbaez@gmail.com>"]
 license = "MIT"
 description = "Command Line Interface (CLI) for stress testing for competitive programming contest"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -3,6 +3,15 @@
 Binary releases can be downloaded manually at:
 https://github.com/LuisMBaezCo/quicktest/releases
 
+### 1.0.1 / 2022.11.12
+
+- fix: issue about .memory_limit method not found on Mac OS' was fixed #92
+- chore: rust version was updated to v1.60.0
+- fix: --tc flag was fixed of cmp docs
+- feat: support for mac installation using curl was added
+- docs: installation for mac os was supported
+- feat: CI only for main, feature and develop branches was added
+
 ### 1.0.0 / 2022.05.30
 
 - feat: report table was added using ascii style [4923d80]

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -26,7 +26,17 @@ Using PowerShell:
 iwr https://luismbaezco.github.io/quicktest/install/install.ps1 -useb | iex
 ```
 
-### macOS, Linux or Windows
+### Mac OS
+
+Using Shell:
+
+```shell
+curl -fsSL https://luismbaezco.github.io/quicktest/install/install.sh | v=1.0.1  sh
+```
+
+Please open a new terminal, or run the following in the existing one `source ~/.zshrc` or `source ~/.bashrc` as appropriate
+
+### Linux, Windows or Mac OS
 If you already have Rust on your system:
 
 ```sh
@@ -35,7 +45,7 @@ cargo install quicktest
 
 If you don't have rust installed on your system, the following command will install Rust and the CLI at once:
 
-### macOS or Linux
+### Linux or Mac OS
 
 Shell:
 


### PR DESCRIPTION
### 1.0.1 / 2022.11.12

- fix: issue about .memory_limit method not found on Mac OS' was fixed #92
- chore: rust version was updated to v1.60.0
- fix: --tc flag was fixed of cmp docs
- feat: support for mac installation using curl was added
- docs: installation for mac os was supported
- feat: CI only for main, feature and develop branches was added